### PR TITLE
Round percentage

### DIFF
--- a/lib/battery-status-view.coffee
+++ b/lib/battery-status-view.coffee
@@ -54,7 +54,7 @@ class BatteryStatusView extends HTMLDivElement
     percentage = null;
     # fetch battery percentage and charge status and update the view
     batteryLevel().then (level) =>
-      percentage = level * 100
+      percentage = (level * 100).toFixed()
       @updateStatusText(percentage)
       isCharging().then (result) =>
         @updateStatusIcon percentage, result


### PR DESCRIPTION
Fixes awkward percentage values (for example 7.00000000000001% or 6.99999999999999997%) in Atom 1.16.0 on Mac.